### PR TITLE
Skip this check when the line contains a URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@
 
 A puppet-lint extension that offers warnings when you include words that
 have a racist history: 'master/slave', 'whitelist/blacklist', for
-starters.  See: <https://tools.ietf.org/id/draft-knodel-terminology-01.html>
+starters.  See: <https://datatracker.ietf.org/doc/draft-knodel-terminology/>
+
+This check will not match against URL's. This is by design to not flag
+for every comment that may contain a github link to a repo using
+'master' as the main branch.
 
 ## Installation
 
-`gem install puppet-lint-racism_terminology-check` 
+`gem install puppet-lint-racism_terminology-check`
 
 ### Author
 

--- a/lib/puppet-lint/plugins/check_racism_terminology.rb
+++ b/lib/puppet-lint/plugins/check_racism_terminology.rb
@@ -2,7 +2,7 @@ PuppetLint.new_check(:racism_terminology) do
   # rubocop:disable Style/Next
   def check
     manifest_lines.each_with_index do |line, idx|
-      if line =~ /\b(master|slave)\b/
+      if line =~ /\b(master|slave)\b/ && line !~ URI::DEFAULT_PARSER.make_regexp
         notify(
           :warning,
           message: 'master/slave terminology, perhaps leader/follower?',
@@ -11,7 +11,7 @@ PuppetLint.new_check(:racism_terminology) do
         )
       end
 
-      if line =~ /\b(blacklist|whitelist)\b/
+      if line =~ /\b(blacklist|whitelist)\b/ && line !~ URI::DEFAULT_PARSER.make_regexp
         notify(
           :warning,
           message: 'blacklist/whitelist terminology, perhaps blocklist/approvelist?',

--- a/puppet-lint_racism_terminology-check.gemspec
+++ b/puppet-lint_racism_terminology-check.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-json_expectations', '~> 2.2'
   spec.add_development_dependency 'rubocop', '~> 0.85.0'
   spec.add_development_dependency 'simplecov', '~> 0.18.0'
+  spec.add_development_dependency 'uri'
 end

--- a/spec/puppet-lint/plugins/check_racism_terminology_spec.rb
+++ b/spec/puppet-lint/plugins/check_racism_terminology_spec.rb
@@ -18,6 +18,15 @@ describe 'racism_terminology' do
     end
   end
 
+  context 'master in a URL' do
+    let(:code) { "file { '/foo/bar': source => 'http://example.com/master' }" }
+    let(:msg) { 'master/slave terminology, perhaps leader/follower?' }
+
+    it 'should not create a warning' do
+      expect(problems).not_to contain_warning(msg).on_line(1)
+    end
+  end
+
   context 'slave' do
     let(:code) { "file { '/tmp/slave': }" }
     let(:msg) { 'master/slave terminology, perhaps leader/follower?' }


### PR DESCRIPTION
Without this patch, comments with github links to projects using 'master' as the main branch will trigger.